### PR TITLE
Feat: add support for passing custom data to iOS shortcuts

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -55,7 +55,10 @@ export const App = () => {
           Shortcuts.addShortcut({
             id,
             title,
-            iconName
+            iconName,
+            userInfo: {
+              key: 'test'
+            }
           })
             .then((response) =>
               Alert.alert(

--- a/ios/RNShortcuts.mm
+++ b/ios/RNShortcuts.mm
@@ -51,6 +51,7 @@ static RNShortcuts *sharedInstance = nil;
     dict[@"title"] = params.title() ?: @"";
     dict[@"subTitle"] = params.subTitle() ?: @"";
     dict[@"longLabel"] = params.longLabel() ?: @"";
+    dict[@"userInfo"] = params.userInfo() ?: nil;
     
     return [dict copy];
 }

--- a/ios/RNShortcutsImpl.swift
+++ b/ios/RNShortcutsImpl.swift
@@ -78,20 +78,20 @@ public class RNShortcutsImpl: NSObject {
             return
         }
         
-        let shortcutItem = createShortcutItem(id: id, title: title, subtitle: params["subTitle"] as? String, iconName: params["iconName"] as? String)
+        let shortcutItem = createShortcutItem(id: id, title: title, subtitle: params["subTitle"] as? String, iconName: params["iconName"] as? String, userInfo: params["userInfo"] as? [String : any NSSecureCoding])
         
         DispatchQueue.main.async {
             operation(shortcutItem)
         }
     }
     
-    private func createShortcutItem(id: String, title: String, subtitle: String?, iconName: String?) -> UIApplicationShortcutItem {
+    private func createShortcutItem(id: String, title: String, subtitle: String?, iconName: String?, userInfo: [String : any NSSecureCoding]?) -> UIApplicationShortcutItem {
         return UIApplicationShortcutItem(
             type: id,
             localizedTitle: title,
             localizedSubtitle: subtitle,
             icon: getUIApplicationShortcutIcon(iconName: iconName),
-            userInfo: nil
+            userInfo: userInfo
         )
     }
     
@@ -116,6 +116,18 @@ public class RNShortcutsImpl: NSObject {
         guard let iconName = iconName else { return nil}
         return UIApplicationShortcutIcon(templateImageName: iconName)
     }
+
+    private func convertToSecureCodingDictionary(from object: NSObject) -> [String: any NSSecureCoding]? {
+        guard let dictionary = object as? [String: Any] else { return nil }
+
+        var secureCodingDict = [String: any NSSecureCoding]()
+
+        for (key, value) in dictionary {
+            secureCodingDict[key] = value
+        }
+
+        return secureCodingDict
+    }
 }
 
 private extension UIApplicationShortcutItem {
@@ -123,7 +135,8 @@ private extension UIApplicationShortcutItem {
         return [
             "id": type,
             "title": localizedTitle,
-            "subtitle": localizedSubtitle
+            "subtitle": localizedSubtitle,
+            "userInfo": userInfo
         ]
     }
 }

--- a/ios/RNShortcutsImpl.swift
+++ b/ios/RNShortcutsImpl.swift
@@ -123,7 +123,7 @@ public class RNShortcutsImpl: NSObject {
         var secureCodingDict = [String: any NSSecureCoding]()
 
         for (key, value) in dictionary {
-            secureCodingDict[key] = value
+            secureCodingDict[key] = value as? any NSSecureCoding
         }
 
         return secureCodingDict
@@ -131,7 +131,7 @@ public class RNShortcutsImpl: NSObject {
 }
 
 private extension UIApplicationShortcutItem {
-    func toDictionary() -> [String: String?] {
+    func toDictionary() -> [String: Any?] {
         return [
             "id": type,
             "title": localizedTitle,

--- a/lib/typescript/commonjs/src/NativeShortcuts.d.ts
+++ b/lib/typescript/commonjs/src/NativeShortcuts.d.ts
@@ -4,6 +4,9 @@ export interface ShortcutResponseType {
     title: string;
     subTitle?: string;
     longLabel?: string;
+    userInfo?: {
+        [key: string]: string | number;
+    };
 }
 export interface ShortcutParamsType extends ShortcutResponseType {
     iconName?: string;

--- a/lib/typescript/module/src/NativeShortcuts.d.ts
+++ b/lib/typescript/module/src/NativeShortcuts.d.ts
@@ -4,6 +4,9 @@ export interface ShortcutResponseType {
     title: string;
     subTitle?: string;
     longLabel?: string;
+    userInfo?: {
+        [key: string]: string | number;
+    };
 }
 export interface ShortcutParamsType extends ShortcutResponseType {
     iconName?: string;

--- a/src/NativeShortcuts.tsx
+++ b/src/NativeShortcuts.tsx
@@ -5,6 +5,9 @@ export interface ShortcutResponseType {
   title: string;
   subTitle?: string;
   longLabel?: string;
+  userInfo?: {
+    [key: string]: string | number;
+  };
 }
 
 export interface ShortcutParamsType extends ShortcutResponseType {
@@ -20,7 +23,7 @@ export interface Spec extends TurboModule {
   isShortcutExists(id: string): Promise<boolean>;
   isShortcutSupported(): Promise<boolean>;
   getInitialShortcutId(): Promise<string>;
-	addListener: (eventType: string) => void;
+  addListener: (eventType: string) => void;
   removeListeners: (count: number) => void;
 }
 


### PR DESCRIPTION
Added ability for passing custom data to shortcuts item as described [here](https://developer.apple.com/documentation/uikit/add-home-screen-quick-actions#Pass-data-with-a-quick-action) by Apple.

Since the values passed into `userInfo` must conform to `NSSecureCoding`. I assume that we can only pass `string` or `number` type on JS layer.

Feel free to provide any feedbacks. Thank you very much.